### PR TITLE
fix: call next handler when no file is found

### DIFF
--- a/lib/azure-storage-file.interceptor.ts
+++ b/lib/azure-storage-file.interceptor.ts
@@ -10,12 +10,15 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { Observable } from 'rxjs';
-import { AzureStorageService, AzureStorageOptions } from './azure-storage.service';
+import {
+  AzureStorageService,
+  AzureStorageOptions,
+} from './azure-storage.service';
 
 export function AzureStorageFileInterceptor(
   fieldName: string,
   localOptions?: MulterOptions,
-  azureStorageOptions?: Partial<AzureStorageOptions>
+  azureStorageOptions?: Partial<AzureStorageOptions>,
 ): Type<NestInterceptor> {
   @Injectable()
   class MixinInterceptor implements NestInterceptor {
@@ -35,14 +38,17 @@ export function AzureStorageFileInterceptor(
       const file = request[fieldName];
 
       if (!file) {
-        Logger.error(
+        Logger.warn(
           'AzureStorageFileInterceptor',
           `Can not intercept field "${fieldName}". Did you specify the correct field name in @AzureStorageFileInterceptor('${fieldName}')?`,
         );
-        return;
+        return next.handle();
       }
 
-      const storageUrl = await this.azureStorage.upload(file, azureStorageOptions);
+      const storageUrl = await this.azureStorage.upload(
+        file,
+        azureStorageOptions,
+      );
       file.storageUrl = storageUrl;
       return next.handle();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
With NestJs it's possible to have a file interceptor even if no file is provided, to let the controller choice for what to do.
The current behavior is returning a 201 response which is misleading, so I changed that to move on to the next handler.
I also changed the log level to warning instead of error.

Issue Number: N/A


## What is the new behavior?
Call the next handler, allowing the controller to choose what to do.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Previously the controller was skipped entirely and a status 201 was returned immediately in case of error, now the controller handler is called properly.

## Other information