### PR TITLE
fix: type uploaded file size as number

### DIFF
--- a/lib/azure-storage.service.spec.ts
+++ b/lib/azure-storage.service.spec.ts
@@ -13,7 +13,7 @@ const file: UploadedFileMetadata = {
   originalname: 'test.txt',
   encoding: 'utf-8',
   mimetype: 'text/plain',
-  size: buffer.length + '',
+  size: buffer.length,
   storageUrl: null,
 };
 

--- a/lib/azure-storage.service.ts
+++ b/lib/azure-storage.service.ts
@@ -34,7 +34,7 @@ export interface UploadedFileMetadata {
   encoding: string;
   mimetype: string;
   buffer: Buffer;
-  size: string;
+  size: number;
   storageUrl?: string;
 }
 


### PR DESCRIPTION
Fixes #250.\n\n## What changed\n- Changed UploadedFileMetadata.size from string to 
umber.\n- Updated the test fixture to match the Express.Multer.File shape, where size is numeric.\n\n## Validation\n- npm run build:lib\n- npm test -- --runInBand\n- git diff --check